### PR TITLE
SCT-2977 Surface Error Locations for sample errors, improve sample errors

### DIFF
--- a/lib/sample_uploader/sample_uploaderImpl.py
+++ b/lib/sample_uploader/sample_uploaderImpl.py
@@ -163,7 +163,7 @@ class sample_uploader:
             )
         else:
             raise ValueError(f"Only SESAR and ENIGMA formats are currently supported for importing samples. "
-                             "File of format {params.get('file_format')} not supported.")
+                             "File of format {params.get('file_format')} is not supported.")
 
         file_links = []
         sample_set_ref = None
@@ -210,7 +210,7 @@ class sample_uploader:
                 if os.path.isfile(os.path.join('/staging', sample_file)):
                     sample_file = os.path.join('/staging', sample_file)
                 else:
-                    raise ValueError(f"input file {sample_file} does not exist.")
+                    raise ValueError(f"Input file {sample_file} does not exist.")
             sample_file_copy = os.path.join(self.scratch, os.path.basename(sample_file))
             shutil.copy(sample_file, sample_file_copy)
             file_links.append({

--- a/lib/sample_uploader/utils/importer.py
+++ b/lib/sample_uploader/utils/importer.py
@@ -262,9 +262,9 @@ def import_samples_from_file(
         raise ValueError(
             f"The expected ID field column \"{id_field}\" could not be found. "
             "Adjust your parameters or input such that the following are correct:\n"
-            "- File Format: {params['file_format']} (the format to which your sample data conforms)\n"
-            "- ID Field: {params['id_field']}\n (the header of the column containing your IDs)"
-            "- Headers Row: {params['header_row_index']} (the row # where column headers are located in your spreadsheet)"
+            f"- File Format: {params['file_format']} (the format to which your sample data conforms)\n"
+            f"- ID Field: {params['id_field']}\n (the header of the column containing your IDs)"
+            f"- Headers Row: {params['header_row_index']} (the row # where column headers are located in your spreadsheet)"
         )
     elif id_field != "id":
         # here we rename whatever the id field was/is to "id"

--- a/lib/sample_uploader/utils/importer.py
+++ b/lib/sample_uploader/utils/importer.py
@@ -77,7 +77,7 @@ def _produce_samples(
     token,
     existing_samples,
     columns_to_input_names,
-    header_row_index
+    first_sample_idx
 ):
     """"""
     samples = []
@@ -108,7 +108,7 @@ def _produce_samples(
         return prev_sample
 
     errors = []
-    for idx, row in df.iterrows():
+    for relative_row_idx, row in df.iterrows():
         try:
             if not row.get('id'):
                 raise SampleContentError(
@@ -182,7 +182,7 @@ def _produce_samples(
                 'admin': row.get('admin')
             })
         except SampleContentError as e:
-            e.row = header_row_index + 1 + idx
+            e.row = first_sample_idx + relative_row_idx
             errors.append(e)
     # add the missing samples from existing_sample_names
     return samples, [existing_sample_names[key] for key in existing_sample_names], errors
@@ -239,6 +239,8 @@ def import_samples_from_file(
     df = load_file(sample_file, header_row_index, date_columns)
 
     errors = []
+    first_sample_idx = header_row_index + 1
+
     # change columns to upload format
     columns_to_input_names = {}
     for col_idx, col_name in enumerate(df.columns):
@@ -319,7 +321,7 @@ def import_samples_from_file(
             token,
             input_sample_set['samples'],
             columns_to_input_names,
-            header_row_index
+            first_sample_idx
         )
         errors += produce_errors
     
@@ -345,8 +347,8 @@ def import_samples_from_file(
 
         err_row_sample_names = {}
         err_sample_name_indices = {}
-        for row_idx, row in df.iterrows():
-            row_pos = header_row_index + 1 + row_idx
+        for relative_row_idx, row in df.iterrows():
+            row_pos =  first_sample_idx + relative_row_idx
             sample_name = row.get('id')
             err_sample_name_indices[sample_name] = row_pos
             err_row_sample_names[row_pos] = sample_name

--- a/lib/sample_uploader/utils/importer.py
+++ b/lib/sample_uploader/utils/importer.py
@@ -89,14 +89,14 @@ def _produce_samples(
                 # now we check if the sample 'id' and 'name' are the same
                 if existing_sample_names[name]['id'] != prev_sample['id']:
                     raise SampleContentError(
-                        f"'kbase_sample_id' and input sample set have different ID's for sample with name \"{name}\""
+                        f"'kbase_sample_id' and input sample set have different ID's for sample with name \"{name}\"",
                         key="id",
                         sample_name=name
                     )
             elif name in existing_sample_names and name != prev_sample['name']:
                 # not sure if this is an error case
                 raise SampleContentError(
-                    f"Cannot rename existing sample from {prev_sample['name']} to {name}"
+                    f"Cannot rename existing sample from {prev_sample['name']} to {name}",
                     key="id",
                     sample_name=name
                 )
@@ -322,6 +322,7 @@ def import_samples_from_file(
     
     if params.get('prevalidate') and not errors:
         error_detail = validate_samples([s['sample'] for s in samples], sample_url, token)
+        print("!!!", error_detail)
         errors += [ SampleContentError(
                 e['message'],
                 sample_name=e['sample_name'], 

--- a/lib/sample_uploader/utils/importer.py
+++ b/lib/sample_uploader/utils/importer.py
@@ -322,7 +322,6 @@ def import_samples_from_file(
     
     if params.get('prevalidate') and not errors:
         error_detail = validate_samples([s['sample'] for s in samples], sample_url, token)
-        print("!!!", error_detail)
         errors += [ SampleContentError(
                 e['message'],
                 sample_name=e['sample_name'], 
@@ -344,22 +343,23 @@ def import_samples_from_file(
         err_row_sample_names = {}
         err_sample_name_indices = {}
         for row_idx, row in df.iterrows():
-            sample_name = row.get('name')
-            err_sample_indices[name] = row_idx
-            err_sample_names[idx] = name
+            sample_name = row.get('id')
+            err_sample_name_indices[sample_name] = row_idx
+            err_row_sample_names[row_idx] = sample_name
 
         for e in errors:
-            if e.column!=None and e.key==None:
-                e.key = err_col_keys[e.key]
-            if e.column==None and e.key!=None:
-                e.column = err_key_indices[e.column]
-            if e.row!=None and e.sample_name==None:
-                e.sample_name = err_row_sample_names[e.sample_name]
-            if e.row==None and e.sample_name!=None:
-                e.row = err_sample_indices[e.row]
+            if e.column!=None and e.key==None and e.column in err_col_keys:
+                e.key = err_col_keys[e.column]
+            if e.column==None and e.key!=None and e.key in err_key_indices:
+                e.column = err_key_indices[e.key]
+            if e.row!=None and e.sample_name==None and e.row in err_row_sample_names:
+                e.sample_name = err_row_sample_names[e.row]
+            if e.row==None and e.sample_name!=None and e.sample_name in err_sample_name_indices:
+                e.row = err_sample_name_indices[e.sample_name]
     else:
         saved_samples = _save_samples(samples, acls, sample_url, token)
         saved_samples += existing_samples
+
     return {
         "samples": saved_samples,
         "description": params.get('description')

--- a/lib/sample_uploader/utils/importer.py
+++ b/lib/sample_uploader/utils/importer.py
@@ -18,6 +18,7 @@ from sample_uploader.utils.sample_utils import (
 from sample_uploader.utils.parsing_utils import upload_key_format
 from sample_uploader.utils.mappings import SAMP_SERV_CONFIG
 from sample_uploader.utils.misc_utils import get_workspace_user_perms
+from sample_uploader.utils.samples_content_error import SampleContentError
 
 # These columns should all be in lower case.
 REGULATED_COLS = ['name', 'id', 'parent_id']
@@ -36,6 +37,11 @@ def validate_params(params):
             sample_file = os.path.join('/staging', sample_file)
         else:
             raise ValueError(f"input file {sample_file} does not exist.")
+    if params.get('id_field'):
+        try: 
+            upload_key_format(params.get('id_field'))
+        except SampleContentError as e:
+            raise ValueError("Invalid ID field in params: {e.message}")
     ws_name = params.get('workspace_name')
     return sample_file
 
@@ -82,85 +88,102 @@ def _produce_samples(
             if name in existing_sample_names and prev_sample['name'] == name:
                 # now we check if the sample 'id' and 'name' are the same
                 if existing_sample_names[name]['id'] != prev_sample['id']:
-                    raise ValueError(f"'kbase_sample_id' and input sample set have different ID's for sample with name \"{name}\"")
+                    raise SampleContentError(
+                        f"'kbase_sample_id' and input sample set have different ID's for sample with name \"{name}\""
+                        key="id",
+                        sample_name=name
+                    )
             elif name in existing_sample_names and name != prev_sample['name']:
                 # not sure if this is an error case
-                raise ValueError(f"Cannot rename existing sample from {prev_sample['name']} to {name}")
+                raise SampleContentError(
+                    f"Cannot rename existing sample from {prev_sample['name']} to {name}"
+                    key="id",
+                    sample_name=name
+                )
         elif name in existing_sample_names:
             prev_sample = get_sample(existing_sample_names[name], sample_url, token)
 
         return prev_sample
 
+    errors = []
     for idx, row in df.iterrows():
-        if not row.get('id'):
-            raise RuntimeError(f"{row.get('id')} evaluates as false - {row.keys()}")
-        # first we check if a 'kbase_sample_id' column is specified
-        kbase_sample_id = None
-        if row.get('kbase_sample_id'):
-            kbase_sample_id = str(row.pop('kbase_sample_id'))
-            if 'kbase_sample_id' in cols:
-                cols.pop(cols.index('kbase_sample_id'))
-        # use name field as name, if there is non-reuse id.
-        if row.get('name'):
-            name = str(row['name'])
-        else:
-            name = str(row['id'])
-        if row.get('parent_id'):
-            parent = str(row.pop('parent_id'))
-            if 'parent_id' in cols:
-                cols.pop(cols.index('parent_id'))
-        if 'id' in cols:
-            cols.pop(cols.index('id'))
-        if 'name' in cols:
-            cols.pop(cols.index('name'))
+        try:
+            if not row.get('id'):
+                raise SampleContentError(
+                    f"Bad sample ID \"{row.get('id')}\" evaluates as false",
+                    key='id',
+                    sample_name=row.get('name')
+                )
+            # first we check if a 'kbase_sample_id' column is specified
+            kbase_sample_id = None
+            if row.get('kbase_sample_id'):
+                kbase_sample_id = str(row.pop('kbase_sample_id'))
+                if 'kbase_sample_id' in cols:
+                    cols.pop(cols.index('kbase_sample_id'))
+            # use name field as name, if there is non-reuse id.
+            if row.get('name'):
+                name = str(row['name'])
+            else:
+                name = str(row['id'])
+            if row.get('parent_id'):
+                parent = str(row.pop('parent_id'))
+                if 'parent_id' in cols:
+                    cols.pop(cols.index('parent_id'))
+            if 'id' in cols:
+                cols.pop(cols.index('id'))
+            if 'name' in cols:
+                cols.pop(cols.index('name'))
 
-        controlled_metadata = generate_controlled_metadata(
-            row,
-            column_groups
-        )
-        user_metadata = generate_user_metadata(
-            row,
-            cols,
-            column_groups,
-            column_unit_regex
-        )
-        source_meta = generate_source_meta(
-            row,
-            controlled_metadata.keys(),
-            columns_to_input_names
-        )
+            controlled_metadata = generate_controlled_metadata(
+                row,
+                column_groups
+            )
+            user_metadata = generate_user_metadata(
+                row,
+                cols,
+                column_groups,
+                column_unit_regex
+            )
+            source_meta = generate_source_meta(
+                row,
+                controlled_metadata.keys(),
+                columns_to_input_names
+            )
 
-        sample = {
-            'node_tree': [{
-                "id": str(row['id']),
-                "parent": None,
-                "type": "BioReplicate",
-                "meta_controlled": controlled_metadata,
-                "meta_user": user_metadata,
-                'source_meta': source_meta
-            }],
-            'name': name,
-        }
-        # get existing sample (if exists)
-        prev_sample = _get_existing_sample(name, kbase_sample_id)
+            sample = {
+                'node_tree': [{
+                    "id": str(row['id']),
+                    "parent": None,
+                    "type": "BioReplicate",
+                    "meta_controlled": controlled_metadata,
+                    "meta_user": user_metadata,
+                    'source_meta': source_meta
+                }],
+                'name': name,
+            }
+            # get existing sample (if exists)
+            prev_sample = _get_existing_sample(name, kbase_sample_id)
 
-        if compare_samples(sample, prev_sample):
-            if sample.get('name') not in existing_sample_names:
-                existing_sample_names[sample['name']] = prev_sample
-            continue
-        elif name in existing_sample_names:
-            existing_sample_names.pop(name)
-        # "save_sample_for_later"
-        samples.append({
-            'sample': sample,
-            'prev_sample': prev_sample,
-            'name': name,
-            'write': row.get('write'),
-            'read': row.get('read'),
-            'admin': row.get('admin')
-        })
+            if compare_samples(sample, prev_sample):
+                if sample.get('name') not in existing_sample_names:
+                    existing_sample_names[sample['name']] = prev_sample
+                continue
+            elif name in existing_sample_names:
+                existing_sample_names.pop(name)
+            # "save_sample_for_later"
+            samples.append({
+                'sample': sample,
+                'prev_sample': prev_sample,
+                'name': name,
+                'write': row.get('write'),
+                'read': row.get('read'),
+                'admin': row.get('admin')
+            })
+        except SampleContentError as e:
+            e.row = idx
+            errors.append(e)
     # add the missing samples from existing_sample_names
-    return samples, [existing_sample_names[key] for key in existing_sample_names]
+    return samples, [existing_sample_names[key] for key in existing_sample_names], errors
 
 
 def _save_samples(samples, acls, sample_url, token):
@@ -212,74 +235,127 @@ def import_samples_from_file(
     sample_file = validate_params(params)
     ws_name = params.get('workspace_name')
     df = load_file(sample_file, header_row_index, date_columns)
+
+    errors = []
     # change columns to upload format
-    # TODO: make sure separate columns are not being renamed to the same thing
-    columns_to_input_names = {upload_key_format(c): c for c in df.columns}
-    df = df.rename(columns={c: upload_key_format(c) for c in df.columns})
+    columns_to_input_names = {}
+    for col_idx, col_name in enumerate(df.columns):
+        try:
+            renamed = upload_key_format(col_name)
+            if renamed in columns_to_input_names:
+                raise SampleContentError(
+                    (f"Duplicate column \"{renamed}\". \"{col_name}\" would overwrite a different column \"{columns_to_input_names[renamed]}\". "
+                    "Rename your columns to be unique alphanumericaly, ignoring whitespace and case."), 
+                    key=col_name
+                )
+            columns_to_input_names[renamed] = col_name
+        except SampleContentError as e:
+            e.column = col_idx
+            errors.append(e)
+
+    df = df.rename(columns={columns_to_input_names[col]: col for col in columns_to_input_names})
     df.replace({n:None for n in NOOP_VALS}, inplace=True)
 
-    if params.get('id_field'):
-        id_field = upload_key_format(params['id_field'])
-        if id_field in list(df.columns):
-            # here we rename whatever the id field was/is to "id"
-            columns_to_input_names["id"] = columns_to_input_names.pop(id_field)
-            df.rename(columns={id_field: "id"}, inplace=True)
-            # remove "id" rename field from column mapping if exists
-            if column_mapping:
-                column_mapping = {key: val for key, val in column_mapping.items() if val != "id"}
-        else:
-            raise ValueError(f"'{params['id_field']}' is not a column field in the input file.")
-    else:
-        print(f"No id_field argument present in params, proceeding with defaults.")
+    # Check that the default or specified ID Field is present
+    id_field = upload_key_format(params['id_field']) if params.get('id_field') else "id"
+    if id_field not in list(df.columns):
+        raise ValueError(
+            f"The expected ID field column \"{id_field}\" could not be found. "
+            "Adjust your parameters or input such that the following are correct:\n"
+            "- File Format: {params['file_format']} (the format to which your sample data conforms)\n"
+            "- ID Field: {params['id_field']}\n (the header of the column containing your IDs)"
+            "- Headers Row: {params['header_row_index']} (the row # where column headers are located in your spreadsheet)"
+        )
+    elif id_field != "id":
+        # here we rename whatever the id field was/is to "id"
+        columns_to_input_names["id"] = columns_to_input_names.pop(id_field)
+        df.rename(columns={id_field: "id"}, inplace=True)
+        # remove "id" rename field from column mapping if exists
+        if column_mapping:
+            column_mapping = {key: val for key, val in column_mapping.items() if val != "id"}
 
-    if column_mapping:
-        df = df.rename(columns=column_mapping)
-    # redundant, even harmful if things get out of sync
-    # verify_columns(df)
-    for key in column_mapping:
-        if key in columns_to_input_names:
-            val = columns_to_input_names.pop(key)
-            columns_to_input_names[column_mapping[key]] = val
+    if not errors:
+        if column_mapping:
+            df = df.rename(columns=column_mapping)
+        # redundant, even harmful if things get out of sync
+        # verify_columns(df)
+        for key in column_mapping:
+            if key in columns_to_input_names:
+                val = columns_to_input_names.pop(key)
+                columns_to_input_names[column_mapping[key]] = val
 
-    if params['file_format'].upper() in ['SESAR', "ENIGMA"]:
-        if 'material' in df.columns:
-            df.rename(columns={"material": params['file_format'].upper() + ":material"}, inplace=True)
-            val = columns_to_input_names.pop("material")
-            columns_to_input_names[params['file_format'].upper() + ":material"] = val
-    if params['file_format'].upper() == "KBASE":
-        if 'material' in df.columns:
-            df.rename(columns={"material": "SESAR:material"}, inplace=True)
-            val = columns_to_input_names.pop("material")
-            columns_to_input_names["SESAR:material"] = val
+        if params['file_format'].upper() in ['SESAR', "ENIGMA"]:
+            if 'material' in df.columns:
+                df.rename(columns={"material": params['file_format'].upper() + ":material"}, inplace=True)
+                val = columns_to_input_names.pop("material")
+                columns_to_input_names[params['file_format'].upper() + ":material"] = val
+        if params['file_format'].upper() == "KBASE":
+            if 'material' in df.columns:
+                df.rename(columns={"material": "SESAR:material"}, inplace=True)
+                val = columns_to_input_names.pop("material")
+                columns_to_input_names["SESAR:material"] = val
 
-    acls = {
-        "read": [],
-        "write": [],
-        "admin": [],
-        "public_read": -1  # set to false (<0)
-    }
-    if params.get('share_within_workspace'):
-        # query workspace for user permissions.
-        acls = get_workspace_user_perms(workspace_url, params.get('workspace_id'), token, username, acls)
-    groups = SAMP_SERV_CONFIG['validators']
+        acls = {
+            "read": [],
+            "write": [],
+            "admin": [],
+            "public_read": -1  # set to false (<0)
+        }
+        if params.get('share_within_workspace'):
+            # query workspace for user permissions.
+            acls = get_workspace_user_perms(workspace_url, params.get('workspace_id'), token, username, acls)
+        groups = SAMP_SERV_CONFIG['validators']
 
-    cols = list(set(df.columns) - set(REGULATED_COLS))
-    sample_url = get_sample_service_url(sw_url)
-    samples, existing_samples = _produce_samples(
-        df,
-        cols,
-        column_groups,
-        column_unit_regex,
-        sample_url,
-        token,
-        input_sample_set['samples'],
-        columns_to_input_names
-    )
-    errors = {}
-    if params.get('prevalidate'):
-        errors = validate_samples([s['sample'] for s in samples], sample_url, token)
+        cols = list(set(df.columns) - set(REGULATED_COLS))
+        sample_url = get_sample_service_url(sw_url)
+        samples, existing_samples, produce_errors = _produce_samples(
+            df,
+            cols,
+            column_groups,
+            column_unit_regex,
+            sample_url,
+            token,
+            input_sample_set['samples'],
+            columns_to_input_names
+        )
+        errors += produce_errors
+    
+    if params.get('prevalidate') and not errors:
+        error_detail = validate_samples([s['sample'] for s in samples], sample_url, token)
+        errors += [ SampleContentError(
+                e['message'],
+                sample_name=e['sample_name'], 
+                node=e['node'], 
+                key=e['key']
+            ) for e in error_detail ]
+
     if errors:
         saved_samples = []
+        # Fill in missing location information for SamplesContentError(s)
+        err_col_keys = {}
+        err_key_indices = {}
+        for col_idx, col_name in enumerate(df.columns):
+            err_col_keys[col_idx] = col_name
+            err_key_indices[col_name] = col_idx
+            if col_name in columns_to_input_names and columns_to_input_names[col_name] != col_name:
+                err_key_indices[columns_to_input_names[col_name]] = col_idx
+
+        err_row_sample_names = {}
+        err_sample_name_indices = {}
+        for row_idx, row in df.iterrows():
+            sample_name = row.get('name')
+            err_sample_indices[name] = row_idx
+            err_sample_names[idx] = name
+
+        for e in errors:
+            if e.column!=None and e.key==None:
+                e.key = err_col_keys[e.key]
+            if e.column==None and e.key!=None:
+                e.column = err_key_indices[e.column]
+            if e.row!=None and e.sample_name==None:
+                e.sample_name = err_row_sample_names[e.sample_name]
+            if e.row==None and e.sample_name!=None:
+                e.row = err_sample_indices[e.row]
     else:
         saved_samples = _save_samples(samples, acls, sample_url, token)
         saved_samples += existing_samples

--- a/lib/sample_uploader/utils/misc_utils.py
+++ b/lib/sample_uploader/utils/misc_utils.py
@@ -41,17 +41,9 @@ def error_ui(errors, scratch):
     """
     template = env.get_template('index.html')
     html_path = os.path.join(scratch, 'index.html')
-    results = []
-    for sample_name in errors:
-        for error in errors[sample_name]:
-            results.append({
-                'sample_name': sample_name,
-                'error': error
-            })
     rendered_html = template.render(
-        results=results
+        results=errors
     )
     with open(html_path, 'w') as f:
         f.write(rendered_html)
     return html_path
-

--- a/lib/sample_uploader/utils/parsing_utils.py
+++ b/lib/sample_uploader/utils/parsing_utils.py
@@ -1,12 +1,13 @@
 # utilities for parsing data.
 import pandas as pd
+from sample_uploader.utils.samples_content_error import SampleContentError
 
 
 def upload_key_format(key):
     try:
         return "_".join(key.strip().lower().replace("(", "").replace(")", "").replace("/", "_").split())
-    except Exception as err:
-        raise Exception(f"could not change key \"{key}\" to upload format - {err}")
+    except SampleContentError as err:
+        raise SampleContentError(f"could not change key \"{key}\" to upload format - {err}")
 
 
 def check_value_in_list(val, array, return_idx=False):

--- a/lib/sample_uploader/utils/samples_content_error.py
+++ b/lib/sample_uploader/utils/samples_content_error.py
@@ -1,5 +1,20 @@
 class SampleContentError(Exception):
-    def __init__(self, message, sample_name=None, node=None, key=None, row=None, column=None):            
+    """                                                                        .
+    Error type for managing errors which arrise at a certain position in 
+    an uploaded datafile. Both sample_name/key and row/column positions are 
+    included as both may be useful the the user trying to identify the source 
+    of the error. However, the aboce are optional as not all the above 
+    information is availible in all places the exception is thrown. 
+    """
+    def __init__(self, message:str, sample_name:str=None, node=None, key=None, row=None, column=None):
+        """
+        :param message: the error message, str
+        :param sample_name: the sample name (user defined ID) related to the error, str or None
+        :param node: the node name related to the error, str or None
+        :param key: the key (column name) related to the error, str or None
+        :param row: the zero-based index of the datafile row related to the error, int or None
+        :param column: the zero-based index of the datafile column related to the error, int or None
+        """
         super().__init__(message)
         self.message = message
         self.sample_name = sample_name

--- a/lib/sample_uploader/utils/samples_content_error.py
+++ b/lib/sample_uploader/utils/samples_content_error.py
@@ -1,8 +1,16 @@
 class SampleContentError(Exception):
     def __init__(self, message, sample_name=None, node=None, key=None, row=None, column=None):            
         super().__init__(message)
+        self.message = message
         self.sample_name = sample_name
         self.node = node
         self.key = key
         self.row = row
         self.column = column
+
+    def locatedMessage(self):
+        sample = self.sample_name if self.sample_name is not None else ""
+        key = self.key if self.key is not None else ""
+        row = self.row if self.row is not None else ""
+        column = self.column if self.column is not None else ""
+        return f"({sample},{key})[{row},{column}]: {self.message}"

--- a/lib/sample_uploader/utils/samples_content_error.py
+++ b/lib/sample_uploader/utils/samples_content_error.py
@@ -1,0 +1,8 @@
+class SampleContentError(Exception):
+    def __init__(self, message, sample_name=None, node=None, key=None, row=None, column=None):            
+        super().__init__(message)
+        self.sample_name = sample_name
+        self.node = node
+        self.key = key
+        self.row = row
+        self.column = column

--- a/lib/sample_uploader/utils/templates/index.html
+++ b/lib/sample_uploader/utils/templates/index.html
@@ -10,14 +10,21 @@
 		<table style="width:100%">
 			<thead>
 				<tr>
-					<th>Sample name</th>
+					<th>Sample Name</th>
+					<th>Key</th>
+					<th>Row</th>
+					<th>Column</th>
 					<th>Error</th>
 				</tr>
 			</thead>
 			<tbody>
-				{% for item in results %}
+				{% for err in results %}
 				<tr>
-				    <td>{{item}}</td>
+				    <td>{{err.sample_name if err.sample_name is not none else ''}}</td>
+						<td>{{err.key if err.key is not none else ''}}</td>
+						<td>{{err.row if err.row is not none else ''}}</td>
+						<td>{{err.column if err.column is not none else ''}}</td>
+						<td>{{err.message}}</td>
 				</tr>
 				{% endfor %}
 			</tbody>

--- a/lib/sample_uploader/utils/templates/index.html
+++ b/lib/sample_uploader/utils/templates/index.html
@@ -17,8 +17,7 @@
 			<tbody>
 				{% for item in results %}
 				<tr>
-				    <td>{{item.sample_name}}</td>
-				    <td>{{item.error}}</td>
+				    <td>{{item}}</td>
 				</tr>
 				{% endfor %}
 			</tbody>

--- a/test/core_tests.py
+++ b/test/core_tests.py
@@ -240,7 +240,7 @@ class sample_uploaderTest(unittest.TestCase):
             'workspace_id': self.wsID,
             'sample_file': sample_file,
             'file_format': "ENIGMA",
-            'header_row_index': 2,
+            'header_row_index': 6,
             'set_name': "test_sample_set_2",
             'description': "this is a test sample set.",
             'prevalidate': 1,
@@ -251,7 +251,9 @@ class sample_uploaderTest(unittest.TestCase):
         with open(os.path.join(self.curr_dir, 'data', 'error_match.json')) as f:
             expected_errors = json.load(f)
         for error in ret['errors']:
-            self.assertEqual(expected_errors.get(error.sample_name), error.message)
+            expected = expected_errors.get(error.sample_name)
+            self.assertEqual(expected['message'], error.message)
+            self.assertEqual(expected['csv_row'], error.row)
 
     # @unittest.skip('x')
     def test_export(self):

--- a/test/core_tests.py
+++ b/test/core_tests.py
@@ -250,8 +250,8 @@ class sample_uploaderTest(unittest.TestCase):
         self.assertTrue(ret.get('errors'))
         with open(os.path.join(self.curr_dir, 'data', 'error_match.json')) as f:
             expected_errors = json.load(f)
-        for sample_name, errors in ret['errors'].items():
-            self.assertEqual(expected_errors.get(sample_name), errors)
+        for error in ret['errors']:
+            self.assertEqual(expected_errors.get(error.sample_name), error.message)
 
     # @unittest.skip('x')
     def test_export(self):

--- a/test/data/error_file.csv
+++ b/test/data/error_file.csv
@@ -1,6 +1,15 @@
+just some, junky pre-header nonsense
+
+empty lines were added for sample error CSV position tests
+
 validation error file,,ontology,ontology,ontology,number
 sample name,id,biome,material,feature,latitude
 biome error,biome_err,ENVO:01001110,ENVO:00002982,ENVO:00000130,0
+
 material error,material_err,ENVO:01000189,ENVO:01000813,ENVO:00000130,88
 feature error,fear_err,ENVO:01000189,ENVO:00002982,ENVO:00010483,-22
+
+
+
+
 out or range error,outta_range,ENVO:01000189,ENVO:00002982,ENVO:00000130,-90.1

--- a/test/data/error_match.json
+++ b/test/data/error_match.json
@@ -1,14 +1,6 @@
 {
-  "biome_err": [
-    "Key biome: Metadata value at key value does not have envo_ontology ancestor term ENVO:00000428"
-  ],
-  "material_err": [
-    "Key ENIGMA:material: Metadata value at key value does not have envo_ontology ancestor term ENVO:00010483"
-  ],
-  "fear_err": [
-    "Key feature: Metadata value at key value does not have envo_ontology ancestor term ENVO:01000813"
-  ],
-  "outta_range": [
-    "Key latitude: Metadata value at key value is not within the range [-90.0, 90.0]"
-  ]
+  "biome_err": "Validation failed: \"Metadata value at key value does not have envo_ontology ancestor term ENVO:00000428\"",
+  "material_err": "Validation failed: \"Metadata value at key value does not have envo_ontology ancestor term ENVO:00010483\"",
+  "fear_err": "Validation failed: \"Metadata value at key value does not have envo_ontology ancestor term ENVO:01000813\"",
+  "outta_range": "Validation failed: \"Metadata value at key value is not within the range [-90.0, 90.0]\""
 }

--- a/test/data/error_match.json
+++ b/test/data/error_match.json
@@ -1,6 +1,18 @@
 {
-  "biome_err": "Validation failed: \"Metadata value at key value does not have envo_ontology ancestor term ENVO:00000428\"",
-  "material_err": "Validation failed: \"Metadata value at key value does not have envo_ontology ancestor term ENVO:00010483\"",
-  "fear_err": "Validation failed: \"Metadata value at key value does not have envo_ontology ancestor term ENVO:01000813\"",
-  "outta_range": "Validation failed: \"Metadata value at key value is not within the range [-90.0, 90.0]\""
+  "biome_err": {
+    "message":"Validation failed: \"Metadata value at key value does not have envo_ontology ancestor term ENVO:00000428\"",
+    "csv_row":6
+  },
+  "material_err": {
+    "message":"Validation failed: \"Metadata value at key value does not have envo_ontology ancestor term ENVO:00010483\"",
+    "csv_row":8
+  },
+  "fear_err": {
+    "message":"Validation failed: \"Metadata value at key value does not have envo_ontology ancestor term ENVO:01000813\"",
+    "csv_row":9
+  },
+  "outta_range": {
+    "message":"Validation failed: \"Metadata value at key value is not within the range [-90.0, 90.0]\"",
+    "csv_row":14
+  }
 }


### PR DESCRIPTION
This PR, along with the SCT-2977 PR to sample_service, add both sample/key and row/column information to all errors surfaced during *validation*. Parsing and bad parameter errors still throw ValueErrors, as these do not have positional information.