### PR TITLE
get dynamic dropdown filter columns directly from sample_search_api

### DIFF
--- a/sample_uploader.spec
+++ b/sample_uploader.spec
@@ -208,6 +208,8 @@ module sample_uploader {
     /*
         Get list of metadata keys/columns from a given list of samplesets. Used to populate filter_sampleset dynamic
         dropdown with valid options from a given list of samples.
+
+        @deprecated sample_search_api.get_sampleset_meta 
     */
 
     typedef structure {

--- a/test/sample_set_filter_test.py
+++ b/test/sample_set_filter_test.py
@@ -221,6 +221,7 @@ class Test(unittest.TestCase):
         ])
         self.assertEqual(len(samples_merge), 206)
 
+    @unittest.skip('deprecated method')
     def test_get_sampleset_meta(self):
         ret = self.serviceImpl.get_sampleset_meta(self.ctx, {
             'sample_set_refs': [self.sample_set_2_ref]

--- a/ui/narrative/methods/filter_samplesets/spec.json
+++ b/ui/narrative/methods/filter_samplesets/spec.json
@@ -76,11 +76,11 @@
             "dynamic_dropdown_options": {
                 "include_user_params": true,
                 "data_source": "custom",
-                "service_function": "sample_uploader.get_sampleset_meta",
+                "service_function": "sample_search_api.get_sampleset_meta",
                 "service_version": "dev",
                 "service_params": [
                     {
-                        "sample_set_ref": "{{sample_set_ref}}"
+                        "sample_set_refs": "{{sample_set_ref}}"
                     }
                 ]
             }


### PR DESCRIPTION
* Calls sample_search_api's get_sampleset method directly to avoid issues with static kbase apps
* deprecates original get_sampleset_meta method