### PR TITLE
fix fields for filter_samplesets dynamic dropdown in spec.json

### DIFF
--- a/ui/narrative/methods/filter_samplesets/spec.json
+++ b/ui/narrative/methods/filter_samplesets/spec.json
@@ -78,6 +78,8 @@
                 "data_source": "custom",
                 "service_function": "sample_uploader.get_sampleset_meta",
                 "service_version": "dev",
+                "selection_id": "field",
+                "description_template": "{{field}}",
                 "service_params": [
                     {
                         "sample_set_ref": "{{sample_set_ref}}"


### PR DESCRIPTION
adds appropriate fields for displaying sampleset columns correctly, namely `description_template` and `selection_id`